### PR TITLE
Fix build issues with LibreSSL

### DIFF
--- a/lib/dnscore/src/dnskey_dsa.c
+++ b/lib/dnscore/src/dnskey_dsa.c
@@ -70,7 +70,7 @@
 #error "OPENSSL_VERSION_NUMBER not defined"
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 /*
  * Backward-compatible interface for 0.9.x
@@ -226,7 +226,7 @@ dnskey_dsa_genkey(u32 size)
     int err;
     DSA* dsa;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
     dsa = DSA_generate_parameters(size, NULL,0, NULL, NULL, NULL, NULL);
 #else
     dsa = DSA_new();

--- a/lib/dnscore/src/dnskey_ecdsa.c
+++ b/lib/dnscore/src/dnskey_ecdsa.c
@@ -79,7 +79,7 @@
 #define DNSKEY_ALGORITHM_ECDSAP256SHA256_NID NID_X9_62_prime256v1
 #define DNSKEY_ALGORITHM_ECDSAP384SHA384_NID NID_secp384r1
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #define SSL_FIELD_GET(st_,f_) if(f_ != NULL) { *f_ = st_->f_; }
 #define SSL_FIELD_SET(st_,f_) if(f_ != NULL) { BN_free(st_->f_); st_->f_ = f_; }

--- a/lib/dnscore/src/dnskey_rsa.c
+++ b/lib/dnscore/src/dnskey_rsa.c
@@ -64,7 +64,7 @@
 
 #define MODULE_MSG_HANDLE g_system_logger
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #define SSL_FIELD_GET(st_,f_) if(f_ != NULL) { *f_ = st_->f_; }
 #define SSL_FIELD_SET(st_,f_) if(f_ != NULL) { BN_free(st_->f_); st_->f_ = f_; }

--- a/lib/dnscore/src/tsig.c
+++ b/lib/dnscore/src/tsig.c
@@ -233,7 +233,7 @@
 tsig_hmac_t
 tsig_hmac_allocate()
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L // ie: 0.9.x
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER) // ie: 0.9.x
     HMAC_CTX *hmac;
     ZALLOC_OR_DIE(HMAC_CTX*, hmac, HMAC_CTX, GENERIC_TAG);
     HMAC_CTX_init(hmac);
@@ -257,7 +257,7 @@ tsig_hmac_free(tsig_hmac_t t)
 {
     HMAC_CTX *hmac = (HMAC_CTX*)t;
     yassert(hmac != NULL);
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
     HMAC_CTX_cleanup(hmac);
     ZFREE(t, HMAC_CTX);
 #else
@@ -268,7 +268,7 @@ tsig_hmac_free(tsig_hmac_t t)
 void tsig_hmac_reset(tsig_hmac_t t)
 {
     HMAC_CTX *hmac = (HMAC_CTX*)t;
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
     HMAC_CTX_cleanup(hmac);
     HMAC_CTX_init(hmac);
 #else


### PR DESCRIPTION
 - Check LIBRESSL_VERSION_NUMBER in addition to OpenSSL > 1.1

LibreSSL forked from OpenSSL 1.0.1f and does not have all features
from 1.1.0.