### PR TITLE
Fix crash on SIGHUP when zone files changed

### DIFF
--- a/sbin/yadifad/database-service-zone-load.c
+++ b/sbin/yadifad/database-service-zone-load.c
@@ -1671,11 +1671,14 @@ database_service_zone_load_thread(void *parms)
         }
         
         database_fire_zone_loaded(zone_desc, zone, return_code);
-        
-        zdb_zone_release(zone);
+
+        if(zone != NULL)
+        {
+            zdb_zone_release(zone);
 #ifdef DEBUG
         zone = NULL;
 #endif
+        }
     }
     else
     {


### PR DESCRIPTION
I'm not sure why
`zone == NULL`
here.

But I've introduced this check to fix SEGV crashes on SIGHUP signals, when the zone files has some changes and need a reload.

```
2019-09-11 10:26:33.008097 | system   | N | reopening '/var/log/yadifad2_3/server.log'
2019-09-11 10:26:33.009073 | system   | N | reopened '/var/log/yadifad2_3/server.log'
2019-09-11 10:26:32.994924 | server   | I | database: reconfigure started
2019-09-11 10:26:32.996271 | server   | I | /etc/yadifad2_3.conf: key and zone sections read
2019-09-11 10:26:33.094523 | server   | I | database: will drop zones not defined in current configuration
2019-09-11 10:26:33.095976 | server   | I | database: reconfigure done
2019-09-11 10:29:56.741720 | server   | I | zone load: 'example.com' load requires the zone to be dropped f
irst ( 0.761002s)
2019-09-11 10:29:58.759331 | server   | I | database: example.com.: zone successfully loaded
2019-09-11 10:37:16.651558 | server   | E | /var/log/yadifad2_3//sig-11-26432
2019-09-11 10:37:16.651595 | server   | E | got signal 11 at time=1568198236 for address 0000000000000080
2019-09-11 10:37:16.651600 | server   | E | rax=0000000000000000
2019-09-11 10:37:16.651604 | server   | E | rcx=0000000000000000
2019-09-11 10:37:16.651626 | server   | E | rdx=00005555555A2870
2019-09-11 10:37:16.651631 | server   | E | rbx=0000000000000000
2019-09-11 10:37:16.651635 | server   | E | rsi=0000000000000000
2019-09-11 10:37:16.651639 | server   | E | rdi=0000000000000070
2019-09-11 10:37:16.651643 | server   | E | rsp=00007FFFE27FDE58
2019-09-11 10:37:16.651648 | server   | E | rbp=0000000000000070
2019-09-11 10:37:16.651652 | server   | E | r8 =0000000000000000
2019-09-11 10:37:16.651656 | server   | E | r9 =0000000000000004
2019-09-11 10:37:16.651660 | server   | E | r10=00007FFFE27FDE30
2019-09-11 10:37:16.651664 | server   | E | r11=0000000000000246
2019-09-11 10:37:16.651668 | server   | E | r12=00007FFF80FF10F0
2019-09-11 10:37:16.651672 | server   | E | r13=0000000000000001
2019-09-11 10:37:16.651676 | server   | E | r14=000055555556E290
2019-09-11 10:37:16.651680 | server   | E | r15=00007FFFF18DB420
2019-09-11 10:37:16.651684 | server   | E | rip=00007FFFF70ADEB0
2019-09-11 10:37:16.651688 | server   | E | efl=0000000000010206
2019-09-11 10:37:16.651833 | server   | E |     [0]: /usr/sbin/yadifad2_3(+0x2bad7) [0x55555557fad7]
2019-09-11 10:37:16.651839 | server   | E |     [1]: /lib64/libpthread.so.0(+0x12360) [0x7ffff70b6360]
2019-09-11 10:37:16.651844 | server   | E |     [2]: /lib64/libpthread.so.0(pthread_mutex_lock+0) [0x7ffff70ad
eb0]
2019-09-11 10:37:16.651849 | server   | E |     [3]: /usr/lib64/libdnsdb.so.6(zdb_zone_release+0x15) [0x7ffff7
f17885]
2019-09-11 10:37:16.651854 | server   | E |     [4]: /usr/sbin/yadifad2_3(+0x1a3b1) [0x55555556e3b1]
2019-09-11 10:37:16.651866 | server   | E |     [5]: /usr/lib64/libdnscore.so.6(+0x37b1c) [0x7ffff7fa6b1c]
2019-09-11 10:37:16.651875 | server   | E |     [6]: /lib64/libpthread.so.0(+0x7569) [0x7ffff70ab569]
2019-09-11 10:37:16.651880 | server   | E |     [7]: /lib64/libc.so.6(clone+0x3f) [0x7ffff6de2a2f]
2019-09-11 10:37:16.651897 | server   | E | pid: 26432 thread id: 00007FFFE27FE700
2019-09-11 10:37:16.651909 | server   | E | page at 0000000000000000 is not mapped.
2019-09-11 10:37:16.744473 | server   | E | CRITICAL ERROR
```