### PR TITLE
Bug-fix for CNAME response which was broken when no CNAME requested and not authoritative for destination

### DIFF
--- a/lib/dnsdb/src/zdb_query_to_wire.c
+++ b/lib/dnsdb/src/zdb_query_to_wire.c
@@ -692,7 +692,6 @@ finger_print zdb_query_to_wire(zdb_query_to_wire_context_t *context)
                         }
 #endif
                         dns_message_set_answer_count(mesg, context->answer_count);
-                        dns_message_set_canonised_fqdn(mesg, zdb_resource_record_data_rdata_const(cname_rr));
                         context->fqdn = cname_owner;
                         context->flags = 0;
                         zdb_query_to_wire(context);


### PR DESCRIPTION
Response was broken when hostname which a CNAME pointing to a host not on this server and if in the request no CNAME was requested but a different type. This should fix this.