### PR TITLE
Set canonised_fqdn to original after recursion

### DIFF
--- a/lib/dnsdb/src/zdb_query_to_wire.c
+++ b/lib/dnsdb/src/zdb_query_to_wire.c
@@ -697,6 +697,9 @@ finger_print zdb_query_to_wire(zdb_query_to_wire_context_t *context)
                         context->flags = 0;
                         zdb_query_to_wire(context);
 
+                        /* We're back from recursion, need to set canonised_fqdn back to the value which is valid in our own context */
+                        dnsname_copy(dns_message_get_canonised_fqdn(mesg), context->original_canonised_fqdn);
+                        
 #if !ZDB_QUERY_TO_WIRE_ASSUME_ZERO
                         dns_message_set_authoritative_answer(mesg);
 


### PR DESCRIPTION
Second attempt to fix CNAME response which can be broken when the CNAME points to a host not known locally. This seems to also fix some issues with denial of existence response for wildcard records with DNSSEC.
