### PR TITLE
nsec3.c: wildcard digest can/should also be used

### DIFF
--- a/lib/dnsdb/src/nsec3.c
+++ b/lib/dnsdb/src/nsec3.c
@@ -502,11 +502,7 @@ void nsec3_wild_closest_encloser_proof(const zdb_zone_t *zone, const dnsname_vec
             dnsname_vector_sub_to_dnsname(qname, wild_top, tmp_fqdn); // wild top here must be 0
             digestname(tmp_fqdn, dnsname_len(tmp_fqdn), salt, salt_len, iterations, &digest[1], false);
             qname_encloser_nsec3 = nsec3_find_interval_start(&n3->items, digest);
-
-            if(qname_encloser_nsec3 != wild_closest_provable_encloser_nsec3)
-            {
-                *qname_encloser_nsec3p = qname_encloser_nsec3;
-            }
+            *qname_encloser_nsec3p = qname_encloser_nsec3;
         }
 
         *wild_encloser_nsec3p = wild_closest_provable_encloser_nsec3;


### PR DESCRIPTION
If the digest of the wildcard host happened to be the nearest to the digest of the requested (non-existent) record, then the proof of non-existence was missing. This should fix this.